### PR TITLE
Spy drone LOS changes

### DIFF
--- a/zscript/augs/spy_drone.zs
+++ b/zscript/augs/spy_drone.zs
@@ -463,16 +463,15 @@ class DD_SpyDrone : Actor
 
 				// Looking for objects in LOS to mark
 				Actor obj;
-				BlockThingsIterator it = BlockThingsIterator.Create(self, 8192.0);
+				ThinkerIterator it = ThinkerIterator.Create("Actor", STAT_DEFAULT);
 
 				Actor prev_targ = self.target;
-				while(it.next())
+				while(obj = Actor(it.next()))
 				{
-					obj = it.thing;
 					if(obj == self)
 						continue;
 					self.target = obj;
-					if(self.checkIfTargetInLOS(90.0))
+					if(self.checkIfTargetInLOS(90.0, 0, 4096.0))
 					{
 						uint oi = parent_aug.mark_objs.find(obj);
 						if(oi == parent_aug.mark_objs.size())

--- a/zscript/augs/spy_drone.zs
+++ b/zscript/augs/spy_drone.zs
@@ -463,15 +463,16 @@ class DD_SpyDrone : Actor
 
 				// Looking for objects in LOS to mark
 				Actor obj;
-				ThinkerIterator it = ThinkerIterator.Create("Actor", STAT_DEFAULT);
+				BlockThingsIterator it = BlockThingsIterator.Create(self, 4096.0);
 
 				Actor prev_targ = self.target;
-				while(obj = Actor(it.next()))
+				while(it.next())
 				{
+					obj = it.thing;
 					if(obj == self)
 						continue;
 					self.target = obj;
-					if(self.checkIfTargetInLOS(90.0, 0, 4096.0))
+					if(self.checkIfTargetInLOS(90.0))
 					{
 						uint oi = parent_aug.mark_objs.find(obj);
 						if(oi == parent_aug.mark_objs.size())


### PR DESCRIPTION
- Revert BlockMapIterator -> ThinkerIterator
- Set LOS check to a max distance of 4096

I know you didn't want a max distance for the spy drone's tagging, but would you be alright with a max distance of 4096? BlockMapIterator is actually worse performing than a ThinkerIterator with the LOS check set to 8192 max, and a max of 4096 is obviously even better performing, only adding ~2-3 ms think time rather than the ~6-7 ms added with a range of 8192. A range of 4096 around the drone is still really large, I believe most doom maps don't have huge outdoor areas significantly larger than 4096, and I think the small decrease in utility is acceptable for the large performance increase.